### PR TITLE
Fix Chat input key handler

### DIFF
--- a/src/Chat.jsx
+++ b/src/Chat.jsx
@@ -78,8 +78,9 @@ function Chat() {
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyPress={(e) => {
+          onKeyDown={(e) => {
             if (e.key === 'Enter') {
+              e.preventDefault();
               handleSendMessage();
             }
           }}


### PR DESCRIPTION
## Summary
- use `onKeyDown` instead of deprecated `onKeyPress` when sending messages

## Testing
- `npm run lint` *(fails: cannot find package '/workspace/careersum-frontend/node_modules/globals/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68885a44d68883258b73a4a27750e798